### PR TITLE
FIX: await interaction defer, so commands do not fail

### DIFF
--- a/interactions/klausuren.ts
+++ b/interactions/klausuren.ts
@@ -182,7 +182,7 @@ exports.Command = async (client: DiscordClient, interaction: DiscordCommandInter
   const now = new Date()
   const embed = await klausuren(client, interaction, now, 'all')
 
-  interaction.deferReply()
+  await interaction.deferReply({ ephemeral: true })
   await interaction.editReply({
     embeds: [embed],
   })

--- a/interactions/wochenplan.ts
+++ b/interactions/wochenplan.ts
@@ -297,7 +297,7 @@ exports.Command = async (client: DiscordClient, interaction: DiscordCommandInter
   const valid_date = option_date.toString() !== 'Invalid Date'
   const date = JSON.stringify(option_date) === 'null' ? new Date() : option_date
 
-  interaction.deferReply({ ephemeral: true })
+  await interaction.deferReply({ ephemeral: true })
   const embed = await wochenplan(client, interaction, date, 'all')
 
   if (!valid_date) {


### PR DESCRIPTION
[Wochenplan](https://github.com/Chr1s70ph/ETIT-Master/blob/8d6aea9034c355c96eeb395e5f575a2b4c61229e/interactions/wochenplan.ts) and [Klausuren](https://github.com/Chr1s70ph/ETIT-Master/blob/8d6aea9034c355c96eeb395e5f575a2b4c61229e/interactions/klausuren.ts) occasionally failed, because defer was not fully acknowledged by the API yet.